### PR TITLE
Fix unescaped quotes and backslash in foreign name

### DIFF
--- a/src/Language/Elemental/AST/Decl.hs
+++ b/src/Language/Elemental/AST/Decl.hs
@@ -23,6 +23,7 @@ module Language.Elemental.AST.Decl
 import Data.Data (Data)
 import Data.Kind qualified as Kind
 import Data.String (IsString)
+import Data.Text qualified as T
 import Data.Text.Short (ShortText, toText)
 import Prettyprinter (Pretty(pretty), dquotes)
 
@@ -99,7 +100,12 @@ newtype ForeignName = ForeignName { unForeignName :: ShortText }
     deriving newtype (Eq, IsString, Ord, Read, Show)
 
 instance Pretty ForeignName where
-    pretty = dquotes . pretty . toText . unForeignName
+    pretty = dquotes . pretty . T.concatMap escape . toText . unForeignName
+      where
+        escape :: Char -> T.Text
+        escape '\\' = T.pack "\\\\"
+        escape '\"' = T.pack "\\\""
+        escape c = T.pack [c]
 
 -- | Substitutes an expression at an index of a declaration list's scope.
 substituteDeclScope

--- a/test/Golden/ForeignNames.elem
+++ b/test/Golden/ForeignNames.elem
@@ -1,0 +1,23 @@
+-- Verify that weird foreign names can still be used.
+
+foreign export "\\" main : IO (∀ 0 → 0)
+foreign export "\"" main : IO (∀ 0 → 0)
+foreign export "\0" main : IO (∀ 0 → 0)
+foreign export "\n" main : IO (∀ 0 → 0)
+foreign export "\r" main : IO (∀ 0 → 0)
+foreign export "\t" main : IO (∀ 0 → 0)
+
+{-
+    These cases are currently disabled because they don't work. The best way of
+    fixing this is probably to change the `ForeignName` type to use bytestring
+    instead of text (the last one isn't valid UTF-8).
+
+foreign export "\xE3\x81\x82" main : IO (∀ 0 → 0)
+foreign export "\xF0\x9F\xA4\x94" main : IO (∀ 0 → 0)
+foreign export "\xEF" main : IO (∀ 0 → 0)
+-}
+
+foreign primitive pureIO : ∀ 0 → IO 0
+
+main = pureIO @(∀ 0 → 0) (Λ λ0 0)
+

--- a/test/Golden/ForeignNames.opt.ll
+++ b/test/Golden/ForeignNames.opt.ll
@@ -1,0 +1,29 @@
+; ModuleID = '<string>'
+source_filename = "test/Golden/ForeignNames.elem"
+
+; Function Attrs: norecurse nounwind readnone
+define void @"\5C"() local_unnamed_addr #0 {
+  ret void
+}
+
+; Function Attrs: norecurse nounwind readnone
+define void @"\22"() local_unnamed_addr #0 {
+  ret void
+}
+
+; Function Attrs: norecurse nounwind readnone
+define void @"\0D"() local_unnamed_addr #0 {
+  ret void
+}
+
+; Function Attrs: norecurse nounwind readnone
+define void @"\0A"() local_unnamed_addr #0 {
+  ret void
+}
+
+; Function Attrs: norecurse nounwind readnone
+define void @"\09"() local_unnamed_addr #0 {
+  ret void
+}
+
+attributes #0 = { norecurse nounwind readnone }


### PR DESCRIPTION
Use `--hedgehog-replay "Size 30 Seed 14244830515000602962 3031273474725822021` to reproduce.